### PR TITLE
Fixed the XML for login buttons being off centre

### DIFF
--- a/Interface/GlueXML/AccountLogin.xml
+++ b/Interface/GlueXML/AccountLogin.xml
@@ -467,7 +467,7 @@
                         <Anchors>
                             <Anchor point="BOTTOM">
                                 <Offset>
-                                    <AbsDimension x="0" y="345"/>
+                                    <AbsDimension x="-3" y="345"/>
                                 </Offset>
                             </Anchor>
                         </Anchors>
@@ -543,9 +543,9 @@
                     <EditBox name="AccountLoginPasswordEdit" letters="16" password="1">
                         <Size x="200" y="37"/>
                         <Anchors>
-                            <Anchor point="BOTTOM">
+                            <Anchor point="TOP" relativeTo="AccountLoginAccountEdit" relativePoint="CENTER">
                                 <Offset>
-                                    <AbsDimension x="0" y="275"/>
+                                    <AbsDimension x="0" y="-50"/>
                                 </Offset>
                             </Anchor>
                         </Anchors>


### PR DESCRIPTION
Big line= middle of screen, small box = middle of the "Username" and "Password" boxes.
https://i.imgur.com/u5m0dap.png

https://i.imgur.com/pGreMeq.png 
you can see it here as well. The username boxes clips the "login" button more on the left than the right.

They were 3 pixels too far to the right, so all "okay" boxes would show as out of alignment. 

After update
After updates: https://i.imgur.com/iRYLA7m.png